### PR TITLE
Updating compiler flags

### DIFF
--- a/config/defaults/config.LINUX_GFORTRAN.mk
+++ b/config/defaults/config.LINUX_GFORTRAN.mk
@@ -1,5 +1,5 @@
-FCOMPILER=mpif90
+FCOMPILER=mpifort
 FCOMPILER_ALL_FLAGS=$(FCOMPILER) -O3
 F2PY_INCLUDES=-I$(MPI_INSTALL_DIR)/include
-F2PY_ALL_FLAGS=--f90exec=$(FCOMPILER) $(F2PY_INCLUDES) --opt='-O3'
-F2PY=python3 -m numpy.f2py 
+F2PY_ALL_FLAGS=--fcompiler=gnu95 --f90exec=$(FCOMPILER) --f77exec=$(FCOMPILER) $(F2PY_INCLUDES) --opt='-O3'
+F2PY=python3 -m numpy.f2py

--- a/config/defaults/config.LINUX_INTEL.mk
+++ b/config/defaults/config.LINUX_INTEL.mk
@@ -1,5 +1,5 @@
 FCOMPILER=mpiifort
 FCOMPILER_ALL_FLAGS=$(FCOMPILER) -O3
 F2PY_INCLUDES=-I$(MPI_INSTALL_DIR)/include
-F2PY_ALL_FLAGS=--f90exec=$(FCOMPILER) $(F2PY_INCLUDES) --opt='-O3'
-F2PY=python3 -m numpy.f2py 
+F2PY_ALL_FLAGS=--fcompiler=intelem --f90exec=$(FCOMPILER) --f77exec=$(FCOMPILER) $(F2PY_INCLUDES) --opt='-O3'
+F2PY=python3 -m numpy.f2py


### PR DESCRIPTION
## Purpose
This PR updates the compiler options in the default config files. It fixes both the compiler type and execs. Without these options set, it tries to detect which compilers and execs are available and fails (see output below).
Nightly builds, and other PRs are failing due to this.

```
INFO: customize UnixCCompiler
INFO: customize UnixCCompiler using build_ext
INFO: get_default_fcompiler: matching types: '['arm', 'gnu95', 'intel', 'lahey', 'pg', 'nv', 'absoft', 'nag', 'vast', 'compaq', 'intele', 'intelem', 'gnu', 'g95', 'pathf95', 'nagfor', 'fujitsu']'
INFO: customize ArmFlangCompiler
INFO: Found executable /home/***/packages/openmpi-3.1.6/opt-gcc/bin/mpif90
WARN: Could not locate executable armflang
WARN: arm: no Fortran 77 compiler found
Traceback (most recent call last):
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/f2py/__main__.py", line 5, in <module>
    main()
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/f2py/f2py2e.py", line 702, in main
    run_compile()
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/f2py/f2py2e.py", line 669, in run_compile
    setup(ext_modules=[ext])
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/core.py", line 169, in setup
    return old_setup(**new_attr)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/command/build.py", line 62, in run
    old_build.run(self)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/command/build.py", line 135, in run
    self.run_command(cmd_name)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/cmd.py", line 313, in run_command
    self.distribution.run_command(command)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/command/build_ext.py", line 288, in run
    self._f77_compiler = new_fcompiler(compiler=self.fcompiler,
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/fcompiler/__init__.py", line 886, in new_fcompiler
    compiler = get_default_fcompiler(plat, requiref90=requiref90,
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/fcompiler/__init__.py", line 857, in get_default_fcompiler
    compiler_type =  _find_existing_fcompiler(matching_compiler_types,
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/fcompiler/__init__.py", line 808, in _find_existing_fcompiler
    c.customize(dist)
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/fcompiler/__init__.py", line 548, in customize
    self.set_library_dirs(self.get_library_dirs())
  File "/home/***/.pyenv/versions/3.8.9/lib/python3.8/site-packages/numpy/distutils/fcompiler/arm.py", line 44, in get_library_dirs
    flang_dir = dirname(self.executables['compiler_f77'][0])
TypeError: 'NoneType' object is not subscriptable
make[1]: *** [Makefile:53: python3] Error 1
```


## Expected time until merged
Should be quick

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
Compile and tests locally.

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [ ] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
