### PR TITLE
Address flake8 issues

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,26 +1,13 @@
+import os
 import numpy as np
 import unittest
+from numpy.testing import assert_almost_equal
 from geograd import geograd_serial as g
 from geograd import geograd_serial_complex as gcs
 from stl import mesh
-import os
+from utils import custom_assert
 
 h = 1e-15
-from openmdao.utils.assert_utils import assert_near_equal
-from numpy.testing import assert_almost_equal
-import warnings
-
-
-def custom_assert(self, truth, approx, base_tol=1e-7):
-    if np.abs(truth) > 0.1:
-        assert_near_equal(truth, approx, tolerance=base_tol)
-    elif np.abs(truth) > 1e-4:
-        assert_near_equal(truth, approx, tolerance=base_tol * 10)
-    elif np.abs(truth) > 5e-9:
-        assert_near_equal(truth, approx, tolerance=base_tol * 100)
-    else:
-        assert_almost_equal(truth, approx, decimal=7)
-
 
 def helper_test_derivatives_translate_objects_random(testcase, objp0, objp1, objp2, smp0, smp1, smp2, n):
     result = g.compute(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)
@@ -39,7 +26,7 @@ def helper_test_derivatives_translate_objects_random(testcase, objp0, objp1, obj
     partial_sum_2 = np.sum(A2_grad, axis=1) + np.sum(B2_grad, axis=1) + np.sum(C2_grad, axis=1)
     cseps = 1e-15
     max_abs_der = 0.0
-    for i in range(n):
+    for _ in range(n):
         # test translating derivatives for cube1
         offsetdir1 = np.random.uniform(-1, 1, size=(3, 1))
         offsetdir1 = offsetdir1 / np.linalg.norm(offsetdir1)
@@ -503,7 +490,6 @@ class BisectSphereTestCase(unittest.TestCase):
         self.base_path = os.path.dirname(os.path.abspath(__file__))
         test_data_path = self.base_path + r"/inputFiles"
         surface_mesh_base = mesh.Mesh.from_file(test_data_path + "/25mmsphere.stl").vectors
-        smSize = surface_mesh_base[:, 0, :].shape[0]
 
         surface_mesh = surface_mesh_base.copy()
         smp0 = surface_mesh[:, 0, :].transpose()
@@ -559,7 +545,6 @@ class BisectCubeTestCase(unittest.TestCase):
         self.base_path = os.path.dirname(os.path.abspath(__file__))
         test_data_path = self.base_path + r"/inputFiles"
         surface_mesh_base = mesh.Mesh.from_file(test_data_path + "/bigcube.stl").vectors
-        smSize = surface_mesh_base[:, 0, :].shape[0]
 
         surface_mesh = surface_mesh_base.copy()
         smp0 = surface_mesh[:, 0, :].transpose()
@@ -570,7 +555,7 @@ class BisectCubeTestCase(unittest.TestCase):
             np.array([0.0, 0.0, 60.0]), np.array([0.0, 80.0, 0.0]), np.array([0.01, -40.0, -40])
         )
         result = g.compute(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)
-        result2 = g.compute_derivs(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)
+        result2 = g.compute_derivs(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)  # noqa F841
         custom_assert(self, result[1], 16.0, base_tol=1e-7)
         helper_test_derivatives_translate_object_given(
             self, objp0, objp1, objp2, smp0, smp1, smp2, np.array([[1.0, 0.0, 0.0]]), 0.0
@@ -583,8 +568,6 @@ class OffsetCubesTestCase(unittest.TestCase):
         test_data_path = self.base_path + r"/inputFiles"
         surface_mesh_base = mesh.Mesh.from_file(test_data_path + "/bigcube.stl").vectors
         object_mesh_base = mesh.Mesh.from_file(test_data_path + "/littlecube.stl").vectors
-        smSize = surface_mesh_base[:, 0, :].shape[0]
-        omSize = object_mesh_base[:, 0, :].shape[0]
 
         surface_mesh = surface_mesh_base.copy()
         smp0 = surface_mesh[:, 0, :].transpose()
@@ -608,8 +591,6 @@ class OffsetSphereIntersectedTestCase(unittest.TestCase):
         test_data_path = self.base_path + r"/inputFiles"
         surface_mesh_base = mesh.Mesh.from_file(test_data_path + "/25mmsphere_reduced.stl").vectors
         object_mesh_base = mesh.Mesh.from_file(test_data_path + "/25mmsphere_reduced.stl").vectors
-        smSize = surface_mesh_base[:, 0, :].shape[0]
-        omSize = object_mesh_base[:, 0, :].shape[0]
 
         surface_mesh = surface_mesh_base.copy()
         smp0 = surface_mesh[:, 0, :].transpose()
@@ -628,7 +609,7 @@ class OffsetSphereIntersectedTestCase(unittest.TestCase):
         objp2 = object_mesh[:, 2, :].transpose() + offsetvec
         result = g.compute(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)
 
-        exact_int = 2 * np.pi * sphere_rad * np.sqrt(1 - (offsetmagnitude / 2 / sphere_rad) ** 2)
+        exact_int = 2 * np.pi * sphere_rad * np.sqrt(1 - (offsetmagnitude / 2 / sphere_rad) ** 2)  # noqa F841
         custom_assert(
             self,
             result[1],
@@ -642,15 +623,13 @@ class OffsetSphereIntersectedTestCase(unittest.TestCase):
         test_data_path = self.base_path + r"/inputFiles"
         surface_mesh_base = mesh.Mesh.from_file(test_data_path + "/25mmsphere_reduced.stl").vectors
         object_mesh_base = mesh.Mesh.from_file(test_data_path + "/25mmsphere_reduced.stl").vectors
-        smSize = surface_mesh_base[:, 0, :].shape[0]
-        omSize = object_mesh_base[:, 0, :].shape[0]
 
         surface_mesh = surface_mesh_base.copy()
         smp0 = surface_mesh[:, 0, :].transpose()
         smp1 = surface_mesh[:, 1, :].transpose()
         smp2 = surface_mesh[:, 2, :].transpose()
 
-        for i in range(5):
+        for _ in range(5):
 
             object_mesh = object_mesh_base.copy()
             # generate a random unit vector direction

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,7 @@ from utils import custom_assert
 
 h = 1e-15
 
+
 def helper_test_derivatives_translate_objects_random(testcase, objp0, objp1, objp2, smp0, smp1, smp2, n):
     result = g.compute(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10)
     perim = result[1]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,12 @@
+# Standard Python modules
 import os
-import numpy as np
 import unittest
-from numpy.testing import assert_almost_equal
+
+# External modules
 from geograd import geograd_serial as g
 from geograd import geograd_serial_complex as gcs
+import numpy as np
+from numpy.testing import assert_almost_equal
 from stl import mesh
 from utils import custom_assert
 

--- a/tests/test_integration_parallel.py
+++ b/tests/test_integration_parallel.py
@@ -516,7 +516,7 @@ class MinDistSTLTestCase1_SplitComm(unittest.TestCase):
             splitcomm.py2f(),
         )
         self.assertAlmostEqual(-2.3197215104930256, result2[0], 8)
-        g.compute_derivs(
+        result3 = g.compute_derivs(  # noqa F841
             self.objp0,
             self.objp1,
             self.objp2,

--- a/tests/test_integration_parallel.py
+++ b/tests/test_integration_parallel.py
@@ -10,6 +10,7 @@ from utils import custom_assert
 
 h = 1e-15
 
+
 def helper_test_derivatives_translate_objects_random(testcase, objp0, objp1, objp2, smp0, smp1, smp2, n, objtol=1000):
     result = g.compute(objp0, objp1, objp2, smp0, smp1, smp2, 0.001, 10, objtol, MPI.COMM_WORLD.py2f())
     perim = result[1]

--- a/tests/test_integration_parallel.py
+++ b/tests/test_integration_parallel.py
@@ -1,11 +1,14 @@
+# Standard Python modules
 import os
-import numpy as np
 import unittest
-from numpy.testing import assert_almost_equal
-from stl import mesh
-from mpi4py import MPI
+
+# External modules
 from geograd import geograd_parallel as g
 from geograd import geograd_parallel_complex as gcs
+from mpi4py import MPI
+import numpy as np
+from numpy.testing import assert_almost_equal
+from stl import mesh
 from utils import custom_assert
 
 h = 1e-15

--- a/tests/test_primitives.py
+++ b/tests/test_primitives.py
@@ -1,8 +1,11 @@
-import numpy as np
+# Standard Python modules
 import unittest
+
+# External modules
 from geograd import triangles as t
 from geograd import triangles_b as tb
 from geograd import triangles_complex as tcs
+import numpy as np
 
 h = 1e-15
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,10 +1,13 @@
-import numpy as np
-import unittest
-from geograd import geograd_parallel as g
-from stl import mesh
+# Standard Python modules
 import os
-from mpi4py import MPI
 import time
+import unittest
+
+# External modules
+from geograd import geograd_parallel as g
+from mpi4py import MPI
+import numpy as np
+from stl import mesh
 
 h = 1e-15
 

--- a/tests/test_speed.py
+++ b/tests/test_speed.py
@@ -1,25 +1,12 @@
 import numpy as np
 import unittest
 from geograd import geograd_parallel as g
-from geograd import geograd_parallel_complex as gcs
 from stl import mesh
 import os
-
-h = 1e-15
 from mpi4py import MPI
 import time
 
-
-def custom_assert(self, truth, approx, base_tol=1e-7):
-    if np.abs(truth) > 0.1:
-        assert_rel_error(self, truth, approx, tolerance=base_tol)
-    elif np.abs(truth) > 1e-4:
-        assert_rel_error(self, truth, approx, tolerance=base_tol * 10)
-    elif np.abs(truth) > 5e-9:
-        assert_rel_error(self, truth, approx, tolerance=base_tol * 100)
-    else:
-        assert_almost_equal(truth, approx, decimal=7)
-
+h = 1e-15
 
 # class MinDistSTLTestCase1(unittest.TestCase):
 #     def setUp(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,15 @@
+# External modules
+import numpy as np
+from numpy.testing import assert_almost_equal
+from openmdao.utils.assert_utils import assert_near_equal
+
+
+def custom_assert(self, truth, approx, base_tol=1e-7):
+    if np.abs(truth) > 0.1:
+        assert_near_equal(truth, approx, tolerance=base_tol)
+    elif np.abs(truth) > 1e-4:
+        assert_near_equal(truth, approx, tolerance=base_tol * 10)
+    elif np.abs(truth) > 5e-9:
+        assert_near_equal(truth, approx, tolerance=base_tol * 100)
+    else:
+        assert_almost_equal(truth, approx, decimal=7)


### PR DESCRIPTION
## Purpose
This PR fixes flake8 linting issues in tests, which are causing tests to fail. Most linting errors were caused by unused variables, but I either removed the reported line or added a `noqa` after the statement. The latter I did mostly for `compute_derivs` statements, but they have no assert tests associated with the output, possibly indicating an incomplete test. This should be checked and verified if someone wants to add more asserts, but it can also be done in a separate PR. I also moved a shared testing function into a `utils.py` module, and reordered inputs. The tests run as before, without causing linting errors. 

Closes #7 

## Expected time until merged
No rush.

## Type of change
<!--
What types of change is it?
Select the appropriate type(s) that describe this PR
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [x] Maintenance update
- [ ] Other (please describe)

## Testing
<!-- Explain the steps needed to test the new code to verify that it does indeed address the issue and produce the expected behavior. -->

## Checklist
<!-- Put an `x` in the boxes that apply. -->

- [x] I have run `flake8` and `black` to make sure the Python code adheres to PEP-8 and is consistently formatted
- [ ] I have formatted the Fortran code with `fprettify` or C/C++ code with `clang-format` as applicable
- [ ] I have run unit and regression tests which pass locally with my changes
- [ ] I have added new tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation
